### PR TITLE
Just to ease OOB build...

### DIFF
--- a/makefile.morphos
+++ b/makefile.morphos
@@ -9,7 +9,7 @@ DATE   = -DSIMPLEMAIL_DATE=\"`date +%d.%m.%Y`\"
 
 # Uncomment the next line if you are cross compiling
 
-CC      = $(CROSS_COMPILE)gcc
+CC      = $(CROSS_COMPILE)gcc-4
 CXX     = $(CROSS_COMPILE)c++
 AS      = $(CROSS_COMPILE)as
 LD      = $(CROSS_COMPILE)ld
@@ -20,7 +20,8 @@ OBJDUMP = $(CROSS_COMPILE)objdump
 # Change these as required
 OPTIMIZE = -O3
 DEBUG = -g -DNDEBUG
-INC = -I. -I./indep-include -I./amiga-mui -I/src/simplemail.git/openssl/objects/host-libnix/include
+OPENSSL_PATH = ../openssl/
+INC = -I. -I./indep-include -I./amiga-mui -I$(OPENSSL_PATH)objects/host-libnix/include
 CFLAGS = -noixemul $(DATE) -DHAVE_STRCASECMP -DHAVE_STRNCASECMP -DHAVE_OPENURL -DAMITCP_SDK -D__MORPHOS_SHAREDLIBS -DUSE_OPENSSL -Wall -fno-strict-aliasing $(OPTIMIZE) $(DEBUG) $(INC)
 
 # Flags passed to gcc during linking
@@ -30,7 +31,7 @@ LINK = -noixemul
 TARGET = SimpleMail
 
 # Additional linker libraries
-LIBS = -ldebug -laboxstubs -L/src/simplemail.git/openssl/objects/host-libnix -lssl -lcrypto
+LIBS = -ldebug -laboxstubs -L$(OPENSSL_PATH)objects/host-libnix -lssl -lcrypto
 
 # Version of the binary to build
 VERSION = 0
@@ -111,7 +112,7 @@ dirs:
 $(TARGET): $(OBJS)
 	$(CC) $(LINK) -o $@.debug $(OBJS) $(LIBS) -Wl,--cref,-M,-Map=$@.map
 	$(STRIP) --remove-section=.comment -o $@ $@.debug
-	chmod a+x SimpleMail
+	chmod a+x $@
 
 ppc-morphos-objs/%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
Hi,

I hope it's ok if I use github as a chatbox with you ;-)

I just switched to GCC4 and removed my hardcoded openssl path.
FYI, I hope to commit my openssl stuff to github soonish so neoman can contribute again.

More annoying: there is clearly some memtrashing going on for a very long time in SimpleMail. I get all kind of crash after I ran it. For some reason, I thought that was related to AmiSSL but it isn't. Both 68k and (using either AmiSSL or OpenSSL) MorphOS builds are impacted so I believe it's a global issue.
