### PR TITLE
Fixed warning.

### DIFF
--- a/amiga-mui/datatypescache.c
+++ b/amiga-mui/datatypescache.c
@@ -142,7 +142,7 @@ Object *LoadAndMapPicture(const char *filename, struct Screen *scr)
 	/* tell DOS not to bother us with requesters */
 	oldwindowptr = MySetProcWindow((APTR)-1);
 
-	o = NewDTObject(filename,
+	o = NewDTObject((char *)filename,
 			DTA_GroupID          , GID_PICTURE,
 			OBP_Precision        , PRECISION_EXACT,
 			PDTA_Screen          , scr,


### PR DESCRIPTION
amiga-mui/datatypescache.c:145:18: warning: passing argument 1 of 'NewDTObject' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]